### PR TITLE
Fix: Correct gtag function declaration

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,9 +12,10 @@
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LM0NLRJBDK"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
+      function gtag() {
+        dataLayer.push(arguments);
+      }
       gtag('js', new Date());
-
       gtag('config', 'G-LM0NLRJBDK');
     </script>
   </head>


### PR DESCRIPTION
The gtag function declaration in index.html was corrected to properly define the function and use the `arguments` object.  This fixes a previously reported error.