### PR TITLE
Fix: Correct gtag function declaration

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,12 +11,9 @@
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-LM0NLRJBDK"></script>
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag('js', new Date());
-      gtag('config', 'G-LM0NLRJBDK');
+      window.dataLayer = window.dataLayer || []; function gtag() {
+      dataLayer.push(arguments); }
+      gtag('js', new Date()); gtag('config', 'G-LM0NLRJBDK');
     </script>
   </head>
 


### PR DESCRIPTION
The gtag function declaration in the index.html file was incorrect.  This commit corrects the declaration to a proper function declaration, ensuring proper functionality.